### PR TITLE
examples: fix adomain to be an array

### DIFF
--- a/Ad Management API 1.0 FINAL.md
+++ b/Ad Management API 1.0 FINAL.md
@@ -514,7 +514,7 @@ POST `https://api.superads.com/management/v1/bidder/496/ads`
 ```json
 {
   "id": "557391",
-  "adomain": "advertiser.com",
+  "adomain": ["advertiser.com"],
   "iurl": "http://cdn.dsp.com/iurls/557391.gif",
   "display": {
     "w": 300,
@@ -691,7 +691,7 @@ POST `https://api.advancedads.com/admgmt/v1/bidder/34/ads`
 {
   "id": "557391",
   "cat": "653",
-  "adomain": "ford.com",
+  "adomain": ["ford.com"],
   "display": {
     "w": 300,
     "h": 250,


### PR DESCRIPTION
In the examples, we have adomain as a string but adCom v1.0 is an array.

This pull request is to fix the examples.

For reference: https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#object--ad-